### PR TITLE
Draft: compiling to WebAssembly support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+run-wasm = ["run", "--release", "--package", "run-wasm", "--", "--release"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,25 @@ winit = { version = "0.29.3", features = ["rwh_05"]}
 unnamed_entity = { version = "0.1", features = ["map"] }
 arrayvec = "0.7.4"
 rand = "0.8.5"
+futures = "0.3"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3.64"
+web-sys = { version = "0.3.64", features = [
+		"GpuTextureFormat",
+		"Window",
+		"ReadableStream",
+		"ReadableStreamDefaultReader",
+		"Storage",
+		"Element",
+		"HtmlElement",
+		"Location"
+	]}
+log = "0.4"
+cpal = { version = "0.15", features = ["wasm-bindgen"] }
+
+[workspace]
+members = ["run-wasm"]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, shrink-to-fit=no">
+  <title>pfr</title>
+  <style type="text/css">
+    body {
+        background-color: #000;
+        margin: 0;
+        overflow: hidden;
+    }
+    .start {
+    	text-align: center;
+    	font-size: 72px;
+    	color: #fff;
+    	cursor: crosshair; /* it's cute */
+    	height: 100%;
+    	width: 100%;
+    	position: fixed;
+    	z-index: 101;
+    }
+    .hidden {
+    	display: none;
+    }
+    canvas {
+    	cursor: none;
+    	/* below fixes weird behavior w/ resizable winit windows */
+    	position: absolute;
+    	top: 0;
+    	left: 0;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="start">Click to start!</div>
+  <script type="module">
+  	document.oncontextmenu = function() {return false;} // buggy, but we can't do better
+
+	window.get_asset = function(a) {
+	  	return(window.assets[a]);
+  	};
+
+  	window.bind_mobile_events = function() {
+  		//const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+  		const isMobile = true;
+  		window.canvas = document.querySelector("canvas");
+  		if (isMobile) {
+  			window.canvas.style.width = "100%";
+  			window.canvas.style.height = "100%";
+		}
+		return isMobile;
+  	}
+  	
+  	window.assets = [];
+  	let promises = [];
+
+	[
+	  "TABLE4.PRG",
+	  "TABLE3.PRG",
+	  "TABLE2.PRG",
+	  "TABLE1.PRG",
+	  "TABLE1.MOD",
+	  "TABLE2.MOD",
+	  "TABLE3.MOD",
+	  "TABLE4.MOD",
+	  "INTRO.MOD",
+	  "INTRO.PRG",
+	  "MOD2.MOD"
+	].forEach(file => {
+	  promises.push(fetch(`/${file}`)
+	    .then(response => response.arrayBuffer())
+	    .then(buffer => {
+	      window.assets[file] = new Uint8Array(buffer);
+	    }));
+	})
+
+	import init from "./pfr.js";
+
+	Promise.all(promises).then(() => {
+		let start = document.querySelector(".start");
+		start.addEventListener("click", () => {
+			init();
+			start.style="display:none;";
+		});
+	})
+
+  </script>
+
+</body>
+
+</html>

--- a/run-wasm/Cargo.toml
+++ b/run-wasm/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "run-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+cargo-run-wasm = "0.3"

--- a/run-wasm/src/main.rs
+++ b/run-wasm/src/main.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let css = r#"body {
+        background-color: #000;
+        margin: 0;
+        overflow: hidden;
+    }"#;
+
+    cargo_run_wasm::run_wasm_with_css(css);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,6 @@ pub mod intro;
 pub mod sound;
 pub mod table;
 pub mod view;
+
+#[cfg(target_arch = "wasm32")]
+pub mod wasm;

--- a/src/sound/player.rs
+++ b/src/sound/player.rs
@@ -127,11 +127,18 @@ pub fn play(module: Mod, sequencer: Option<Arc<dyn Sequencer>>) -> Player {
         pattern_break: None,
         jump: None,
     };
+    
     let config = StreamConfig {
         channels: 2,
         sample_rate: SampleRate(sample_rate),
+        
+        #[cfg(target_arch = "wasm32")]
+        buffer_size: BufferSize::Fixed(sample_rate / 32),
+        
+        #[cfg(not(target_arch = "wasm32"))]
         buffer_size: BufferSize::Fixed(sample_rate / 50),
     };
+    
     let stream = device
         .build_output_stream(
             &config,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,47 @@
+use std::path::PathBuf;
+use wasm_bindgen::prelude::*;
+use js_sys::{JSON, Array, Uint8Array};
+use crate::config::ConfigStore;
+
+pub struct WasmConfigStore {
+    pub path: PathBuf,
+    local_storage: web_sys::Storage
+}
+
+impl WasmConfigStore {
+    pub fn new(path: impl Into<PathBuf>) -> Self {        
+        let window = web_sys::window();
+        let local_storage = window.unwrap().local_storage().unwrap().unwrap();
+        Self
+        {
+            path: path.into(),
+            local_storage,
+        }
+    }
+}
+
+impl ConfigStore for WasmConfigStore {
+    fn load(&self, name: &str) -> Option<Vec<u8>> {
+        let value = self.local_storage.get_item(name);
+        let buffer: JsValue = JSON::parse(&value.unwrap()?).ok()?;
+
+        let array = Uint8Array::new(&buffer);
+        Some(array.to_vec())
+    }
+    fn save(&self, name: &str, data: &[u8]) {
+        let array = Array::from(&Uint8Array::from(data));
+
+        let buffer: String = JSON::stringify(&JsValue::from(&array)).unwrap().into();
+        let _ = self.local_storage.set_item(&name, &buffer);
+    }
+}
+
+#[wasm_bindgen]
+extern "C" {
+    pub fn get_asset(s: &str) -> Vec<u8>;
+}
+
+#[wasm_bindgen]
+extern "C" {
+    pub fn bind_mobile_events();
+}


### PR DESCRIPTION
how to run this:

1. `cargo run-wasm --package pfr` (optionally add `--host 0.0.0.0` for testing from another device)
2. copy `index.html` to `target/wasm-examples/pfr/asdf.html`
3. copy game files to `target/wasm-examples/pfr/`
4. launch a browser pointed to http://localhost:8000/asdf.html

also done here: 1-5 buttons mapped to F1-F5 in menu; this is because browsers don't really like when you use function keys :p - also, function keys don't exist on chromebooks, etc

TODO:
- more code cleanup (marked most areas that are *bad* with a TODO)
- investigate why tf it lags on firefox (works OK on chromium)
- block menu on right click (for mouse controls)
- cleanup deps (?)
- focus on canvas element on game startup
- proper mechanism for asking browser to give permission for audio playback

gosh that was... the most fun i'Ve had coding in a while